### PR TITLE
LIBS-61: (logs) ~UNDEFINED~ affiché lorsqu'on essaie d'ouputer 0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 aliases:
-  - &composer_install_cache_key v1-composer-install-{{ checksum "composer.json" }}
+  - &composer_install_cache_key v2-composer-install-{{ checksum "composer.json" }}
 
 workflows:
   version: 2
@@ -13,7 +13,6 @@ workflows:
 
 jobs:
   build:
-    working_directory: ~/
     docker:
     - image: composer/composer:php5-alpine
     steps:
@@ -23,14 +22,13 @@ jobs:
         - *composer_install_cache_key
     - run: apk update && apk add openssh-keysign
     - run: mkdir -p ~/.ssh/ && ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-    - run: test ! -d vendor && composer install -n --prefer-dist --dev || true
+    - run: test -d vendor || composer install -n --prefer-dist --dev
     - save_cache:
         key: *composer_install_cache_key
         paths:
           - vendor
 
   phpunit:
-    working_directory: ~/
     docker:
     - image: php:5.6-cli-alpine
       command: /sbin/init

--- a/src/Traits/Interpolate.php
+++ b/src/Traits/Interpolate.php
@@ -40,6 +40,7 @@ trait Interpolate
      */
     private function canBeInterpolated($value)
     {
-        return $value && !is_array($value) && (!is_object($value) || method_exists($value, '__toString'));
+        return !is_null($value) && !is_array($value) && (!is_object($value) || method_exists($value, '__toString'));
     }
+
 }

--- a/tests/Formatter/ContextStringifierTest.php
+++ b/tests/Formatter/ContextStringifierTest.php
@@ -23,7 +23,7 @@ class ContextStringifierTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->context_stringifier = new \Kronos\Log\Formatter\ContextStringifier();
+        $this->context_stringifier = new ContextStringifier();
     }
 
     public function test_EmptyContext_Stringify_ShouldReturnEmptyString()
@@ -218,24 +218,5 @@ class ContextStringifierTest extends \PHPUnit_Framework_TestCase
         $stringifiedContext = $this->context_stringifier->stringifyArray($context);
 
         $this->assertEquals($expectedArray, $stringifiedContext);
-    }
-}
-
-class ObjectWithoutToString
-{
-    public $property;
-}
-
-class ObjectWithToString
-{
-
-    /**
-     * @var string
-     */
-    public $property;
-
-    public function __toString()
-    {
-        return $this->property;
     }
 }

--- a/tests/Formatter/ObjectWithToString.php
+++ b/tests/Formatter/ObjectWithToString.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kronos\Tests\Log\Formatter;
+
+class ObjectWithToString
+{
+
+    /**
+     * @var string
+     */
+    public $property;
+
+    public function __toString()
+    {
+        return $this->property;
+    }
+}

--- a/tests/Formatter/ObjectWithoutToString.php
+++ b/tests/Formatter/ObjectWithoutToString.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kronos\Tests\Log\Formatter;
+
+class ObjectWithoutToString
+{
+    public $property;
+}

--- a/tests/Traits/InterpolateTest.php
+++ b/tests/Traits/InterpolateTest.php
@@ -72,4 +72,15 @@ class InterpolateTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(self::MESSAGE_WITH_UNDEFINED, $interpolated_message);
     }
+
+    public function test_ZeroInContext_Interpolate_ShouldReplaceWithZero()
+    {
+        $original_message = self::A_MESSAGE;
+        $value = 0;
+        $expectedMessage = str_replace('{' . self::KEY . '}', $value, self::A_MESSAGE);
+
+        $interpolated_message = $this->interpolator->interpolate($original_message, [self::KEY => $value]);
+
+        $this->assertEquals($expectedMessage, $interpolated_message);
+    }
 }


### PR DESCRIPTION
Si $value = 0, return $value va retourner 0 qui va être interprété comme false.
Fix: on doit vérifier si value est !null.