### PR TITLE
feat: add support to fluentbit

### DIFF
--- a/src/Builder/Strategy/Fluentd.php
+++ b/src/Builder/Strategy/Fluentd.php
@@ -15,6 +15,7 @@ class Fluentd extends AbstractWriter
     const HOSTNAME = 'hostname';
     const PORT = 'port';
     const WRAP_CONTEXT_IN_META = 'wrapContextInMeta';
+    const FLUENT_BIT = 'fluentBit';
 
     /**
      * @var ExceptionTraceHelper
@@ -42,13 +43,17 @@ class Fluentd extends AbstractWriter
         $tag = $settings[self::TAG];
         $wrapContextInMeta = isset($settings[self::WRAP_CONTEXT_IN_META]) ? filter_var($settings[self::WRAP_CONTEXT_IN_META],
             FILTER_VALIDATE_BOOLEAN) : false;
+        $fluentBit = isset($settings[self::FLUENT_BIT]) ? filter_var($settings[self::FLUENT_BIT],FILTER_VALIDATE_BOOLEAN) : false;
 
         $writer = new \Kronos\Log\Writer\Fluentd(
             $hostname,
             $port,
             $tag,
             $application,
-            $wrapContextInMeta
+            $wrapContextInMeta,
+            null,
+            null,
+            $fluentBit
         );
 
         $exceptionTraceBuilder = $this->exceptionTraceHelper->getExceptionTraceBuilderForSettings($settings);

--- a/src/Factory/Fluentd.php
+++ b/src/Factory/Fluentd.php
@@ -5,16 +5,19 @@ namespace Kronos\Log\Factory;
 
 
 use Fluent\Logger\FluentLogger;
+use Fluent\Logger\PackerInterface;
 
 class Fluentd
 {
     /**
      * @param string $hostname
      * @param int $port
+     * @param array $options
+     * @param PackerInterface $packer
      * @return FluentLogger
      */
-    public function createFluentLogger($hostname, $port)
+    public function createFluentLogger($hostname, $port, $options = [], PackerInterface $packer = null)
     {
-        return new FluentLogger($hostname, $port);
+        return new FluentLogger($hostname, $port, $options, $packer);
     }
 }

--- a/src/Factory/Fluentd/FluentBitJsonPacker.php
+++ b/src/Factory/Fluentd/FluentBitJsonPacker.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace Kronos\Log\Factory\Fluentd;
+
+use Fluent\Logger\FluentLogger;
+use Fluent\Logger\Entity;
+use Fluent\Logger\PackerInterface;
+
+class FluentBitJsonPacker implements PackerInterface
+{
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * pack entity as a json string for fluent bit with the ultimate tag name encoded as a key (no time)
+     *
+     * @param Entity $entity
+     * @return string
+     */
+    public function pack(Entity $entity)
+    {
+        $data = $entity->getData();
+        $data['_tag'] = $entity->getTag();
+        return json_encode($data);
+    }
+}

--- a/src/Writer/Fluentbit.php
+++ b/src/Writer/Fluentbit.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Kronos\Log\Writer;
+
+
+use Fluent\Logger\FluentLogger;
+use \Kronos\Log\Factory\Fluentd\FluentBitJsonPacker;
+
+class Fluentbit extends Fluentd
+{
+    /**
+     * @return FluentLogger
+     */
+    protected function initializeLogger()
+    {
+        if ($this->logger === null) {
+            $this->logger = $this->factory->createFluentLogger($this->hostname, $this->port, [], new FluentBitJsonPacker());
+        }
+
+        return $this->logger;
+    }
+}

--- a/tests/Builder/Strategy/FluentdTest.php
+++ b/tests/Builder/Strategy/FluentdTest.php
@@ -164,4 +164,17 @@ class FluentdTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($retVal->willWrapContextInMeta());
     }
+
+    public function test_fluentBitToTrue_buildFromArray_getFluentBitReturnsTrue()
+    {
+        $params = [
+            'hostname' => 'php.application',
+            'tag' => 'php.application',
+            'fluentBit' => true
+        ];
+
+        $retVal = $this->strategy->buildFromArray($params);
+
+        $this->assertTrue($retVal->getFluentBit());
+    }
 }

--- a/tests/Writer/FluentdTest.php
+++ b/tests/Writer/FluentdTest.php
@@ -6,6 +6,7 @@ namespace Kronos\Tests\Log\Writer;
 
 use Fluent\Logger\FluentLogger;
 use Kronos\Log\Writer\Fluentd;
+use Kronos\Log\Factory\Fluentd\FluentBitJsonPacker;
 use Psr\Log\LogLevel;
 
 class FluentdTest extends \PHPUnit\Framework\TestCase
@@ -42,7 +43,7 @@ class FluentdTest extends \PHPUnit\Framework\TestCase
         $givenHostname = "localhost";
         $this->writer = new Fluentd($givenHostname, 24224, "test", null, false, $this->factory);
 
-        $this->factory->expects($this->once())->method('createFluentLogger')->with($givenHostname, $this->anything());
+        $this->factory->expects($this->once())->method('createFluentLogger')->with($givenHostname, $this->anything(), $this->anything(), $this->anything());
 
         $this->writer->log(LogLevel::INFO, "test");
     }
@@ -53,6 +54,15 @@ class FluentdTest extends \PHPUnit\Framework\TestCase
         $this->writer = new Fluentd("localhost", $givenPort, "test", null, false, $this->factory);
 
         $this->factory->expects($this->once())->method('createFluentLogger')->with($this->anything(), $givenPort);
+
+        $this->writer->log(LogLevel::INFO, "test");
+    }
+
+    public function test_uninitialized_log_CreatesLoggerWithFluentBitPacker()
+    {
+        $this->writer = new Fluentd("localhost", 24224, "test", null, false, $this->factory, null, true);
+
+        $this->factory->expects($this->once())->method('createFluentLogger')->with($this->anything(), $this->anything(), $this->anything(), $this->isInstanceOf(FluentBitJsonPacker::class));
 
         $this->writer->log(LogLevel::INFO, "test");
     }


### PR DESCRIPTION
This PR add support to Fluentbit `tcp` input connection.

Without fluentBit support, values sent to fluentbit looks like this ->
```
{"msg":["php.crm", 1557347185, {"meta":{"_trace":{"local":"1-1557347185-08009b6023d7f965ca41b55d", "root":"1-1557347185-08009b6023d7f965ca41b55d"}}, "level":"warning", "_app":"crm", "message":"test"}]}
```

Instead of this ->
```
{"meta":{"_trace":{"local":"1-1557347202-d2e338325a7b86212e435d5d", "root":"1-1557347202-d2e338325a7b86212e435d5d"}}, "level":"warning", "_app":"crm", "message":"test", "_tag":"php.crm"}
```

The output is generated using `kronos-log` fluentd configuration ->
```
    - type: fluentd
      settings:
        hostname: localhost
        tag: php.crm
        wrapContextInMeta: true
        fluentBit: true
```
```
\Kronos\Log\LogService::warning('test');
```