### PR TITLE
Require PHP8.1 

### DIFF
--- a/.github/workflows/php-security.yml
+++ b/.github/workflows/php-security.yml
@@ -10,7 +10,7 @@ jobs:
     uses: equisoft-actions/php-workflows/.github/workflows/php-security.yml@v3
     with:
       publish-reports: true
-      php-version: '7.4'
+      php-version: '8.1'
       extensions: pcov
     secrets:
       GPR_KEY: ${{ secrets.GPR_KEY }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,15 +13,6 @@ jobs:
     uses: equisoft-actions/php-workflows/.github/workflows/php-library.yml@v3
     with:
       checks: phpunit,psalm
-      php-version: '7.4'
-      extensions: pcov
-    secrets:
-      GPR_KEY: ${{ secrets.GPR_KEY }}
-
-  php-library-8-1:
-    uses: equisoft-actions/php-workflows/.github/workflows/php-library.yml@v3
-    with:
-      checks: phpunit,psalm,qodana
       php-version: '8.1'
       extensions: pcov
     secrets:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		}
 	},
 	"require": {
-		"php": "^7.4 || ^8.1",
+		"php": "^8.1",
 		"psr/log": "^1.0"
 	},
 	"suggest": {
@@ -42,7 +42,7 @@
 	},
   "config": {
     "platform": {
-      "php": "7.4"
+      "php": "8.1"
     },
 		"allow-plugins": {
 			"composer/package-versions-deprecated": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aaafabffbe427def7ab013b900d64c9f",
+    "content-hash": "8521602ccd3a9c2ec31583dc46f84ef7",
     "packages": [
         {
             "name": "psr/log",
@@ -5623,11 +5623,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ^8.1"
+        "php": "^8.1"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4"
+        "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Maintenant que les autres projets rendus en 8.1 on peut finalement mettre a jour la librairie pour etre en 8.1.

Ceci va aussi permettre de mettre a jour certaines librairies qui etaient bloquées.


Note: Attendre avant de faire une nouvelle release (4.0.0) ou pourrait inclure l'update de psr/log v3 https://github.com/kronostechnologies/kronos-log/pull/52 dans la meme release.


