### PR TITLE
LoggerAware: fix psr loggerAwareTrait import

### DIFF
--- a/src/Traits/LoggerAware.php
+++ b/src/Traits/LoggerAware.php
@@ -2,12 +2,13 @@
 
 namespace Kronos\Log\Traits;
 
-use  Kronos\Log\Logger;
+use Kronos\Log\Logger;
 use Throwable;
+use Psr\Log\LoggerAwareTrait;
 
 trait LoggerAware
 {
-    use \Psr\Log\LoggerAwareTrait;
+    use LoggerAwareTrait;
 
     /**
      * System is unusable.


### PR DESCRIPTION
L'importation erronée de `Psr\Log\LoggerAwareTrait` causait des problèmes pour le worker de fna.