### PR TITLE
LIBS-243 Add LoggerInterface and LogLocatorLogger

### DIFF
--- a/src/LogLocator.php
+++ b/src/LogLocator.php
@@ -3,55 +3,44 @@
 namespace Kronos\Log;
 
 use Kronos\Log\Writer\TriggerError;
+use Psr\Log\LoggerInterface as PsrLoggerInterface;
 
 class LogLocator
 {
+    private static ?LoggerInterface $logger = null;
 
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    private static $logger;
-
-    /**
-     * @param \Psr\Log\LoggerInterface $logger
-     * @param bool $force
-     */
-    public static function setLogger(\Psr\Log\LoggerInterface $logger, $force = false)
+    public static function setLogger(LoggerInterface|PsrLoggerInterface $logger, bool $force = false): void
     {
+        if (!$logger instanceof LoggerInterface) {
+            $logger = new LoggerDecorator($logger);
+        }
+
         if (!self::isLoggerSet() || $force) {
             self::$logger = $logger;
         }
     }
 
-    /**
-     * @return bool
-     */
-    public static function isLoggerSet()
+    public static function isLoggerSet(): bool
     {
-        return isset(self::$logger);
+        return self::$logger !== null;
     }
 
-    /**
-     * @return \Psr\Log\LoggerInterface
-     */
-    public static function getLogger()
+    public static function getLogger(): LoggerInterface
     {
         if (!self::isLoggerSet()) {
             self::setLogger(self::createDefaultLogger());
         }
 
+        /** @psalm-var LoggerInterface self::$logger */
         return self::$logger;
     }
 
-    public static function unsetLogger()
+    public static function unsetLogger(): void
     {
         self::$logger = null;
     }
 
-    /**
-     * @return Logger
-     */
-    public static function createDefaultLogger()
+    public static function createDefaultLogger(): Logger
     {
         $logger = new Logger();
         $logger->addWriter(new TriggerError());

--- a/src/LogLocatorLogger.php
+++ b/src/LogLocatorLogger.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Kronos\Log;
+
+use Stringable;
+use Throwable;
+
+class LogLocatorLogger implements LoggerInterface
+{
+    private static ?self $instance = null;
+
+    public static function getInstance(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    public function emergency(string|Stringable $message, array $context = []): void
+    {
+        LogLocator::getLogger()->emergency($message, $context);
+    }
+
+    public function alert(string|Stringable $message, array $context = []): void
+    {
+        LogLocator::getLogger()->alert($message, $context);
+    }
+
+    public function critical(string|Stringable $message, array $context = []): void
+    {
+        LogLocator::getLogger()->critical($message, $context);
+    }
+
+    public function error(string|Stringable $message, array $context = []): void
+    {
+        LogLocator::getLogger()->error($message, $context);
+    }
+
+    public function warning(string|Stringable $message, array $context = []): void
+    {
+        LogLocator::getLogger()->warning($message, $context);
+    }
+
+    public function notice(string|Stringable $message, array $context = []): void
+    {
+        LogLocator::getLogger()->notice($message, $context);
+    }
+
+    public function info(string|Stringable $message, array $context = []): void
+    {
+        LogLocator::getLogger()->info($message, $context);
+    }
+
+    public function debug(string|Stringable $message, array $context = []): void
+    {
+        LogLocator::getLogger()->debug($message, $context);
+    }
+
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        LogLocator::getLogger()->log($level, $message, $context);
+    }
+
+    public function exception(string $message, Throwable $exception, array $context = array()): void
+    {
+        LogLocator::getLogger()->exception($message, $exception, $context);
+    }
+
+    public function addContext(string $key, mixed $value): void
+    {
+        LogLocator::getLogger()->addContext($key, $value);
+    }
+
+    public function addContextArray(array $context): void
+    {
+        LogLocator::getLogger()->addContextArray($context);
+    }
+}

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -2,9 +2,9 @@
 
 namespace Kronos\Log;
 
-use Kronos\Log\Writer\Console;
+use Throwable;
 
-class Logger extends \Psr\Log\AbstractLogger
+class Logger extends \Psr\Log\AbstractLogger implements LoggerInterface
 {
 
     const EXCEPTION_CONTEXT = 'exception';
@@ -20,26 +20,22 @@ class Logger extends \Psr\Log\AbstractLogger
     /**
      * @param WriterInterface $writer
      */
-    public function addWriter(WriterInterface $writer)
+    public function addWriter(WriterInterface $writer): void
     {
         $this->writers[] = $writer;
     }
 
-    /**
-     * @param $key String
-     * @param $value Mixed
-     */
-    public function addContext($key, $value)
+    public function addContext(string $key, mixed $value): void
     {
         $this->context[$key] = $value;
     }
 
-    public function addContextArray(array $context)
+    public function addContextArray(array $context): void
     {
         $this->context = array_merge($this->context, $context);
     }
 
-    public function setWriterCanLog($writer_name, $can_log = true)
+    public function setWriterCanLog($writer_name, $can_log = true): void
     {
         /** @var class-string $writerClassName */
         $writerClassName = self::WRITER_PATH . ucfirst($writer_name);
@@ -61,5 +57,14 @@ class Logger extends \Psr\Log\AbstractLogger
                 }
             }
         }
+    }
+
+    /**
+     * Log Error with exception context
+     */
+    public function exception(string $message, Throwable $exception, array $context = array()): void
+    {
+        $context[self::EXCEPTION_CONTEXT] = $exception;
+        $this->error($message, $context);
     }
 }

--- a/src/LoggerDecorator.php
+++ b/src/LoggerDecorator.php
@@ -2,27 +2,23 @@
 
 namespace Kronos\Log;
 
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerInterface as PsrLoggerInterface;
 use Psr\Log\LogLevel;
+use Throwable;
 
 class LoggerDecorator implements LoggerInterface
 {
-    /**
-     * @var string
-     */
-    private $level = LogLevel::DEBUG;
-    /**
-     * @var LoggerInterface
-     */
-    private $delegate;
+    private string $level = LogLevel::DEBUG;
+
+    private PsrLoggerInterface $delegate;
 
     public function __construct(
-        LoggerInterface $delegate
+        LoggerInterface|PsrLoggerInterface $delegate
     ) {
         $this->delegate = $delegate;
     }
 
-    public function setLevel(string $level)
+    public function setLevel(string $level): void
     {
         $this->level = $level;
     }
@@ -72,5 +68,25 @@ class LoggerDecorator implements LoggerInterface
         if (!LogLevelHelper::isLower($this->level, (string)$level)) {
             $this->delegate->log($level, $message, $context);
         }
+    }
+
+    public function addContext(string $key, mixed $value): void
+    {
+        if($this->delegate instanceof LoggerInterface) {
+            $this->delegate->addContext($key, $value);
+        }
+    }
+
+    public function addContextArray(array $context): void
+    {
+        if($this->delegate instanceof LoggerInterface) {
+            $this->delegate->addContextArray($context);
+        }
+    }
+
+    public function exception(string $message, Throwable $exception, array $context = array()): void
+    {
+        $context[Logger::EXCEPTION_CONTEXT] = $exception;
+        $this->error($message, $context);
     }
 }

--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kronos\Log;
+
+use Throwable;
+
+interface LoggerInterface extends \Psr\Log\LoggerInterface
+{
+    /**
+     * Log Error with exception context
+     */
+    public function exception(string $message, Throwable $exception, array $context = array()): void;
+
+    public function addContext(string $key, mixed $value): void;
+
+    public function addContextArray(array $context): void;
+}


### PR DESCRIPTION
https://jira.equisoft.com/browse/LIBS-243

- Lorsqu'un logger est injecté par le DI, il n'utilise plus le LogLocator. Il reste alors collé avec un logger qui log seulement des E_NOTICE php
- Les fonctions d'ajout de contexte et exception() sont tannante à utiliser car elles ne sont pas dans l'interface Psr

CRM https://github.com/kronostechnologies/kronos-crm/pull/9776/