### PR TITLE
CRM-27749/ PHP 8.4 - stop using E_USER_ERROR

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -57,7 +57,7 @@ class Logger extends \Psr\Log\AbstractLogger implements LoggerInterface
                 try {
                     $writer->log($level, $message, $context + $this->context);
                 } catch (\Exception $exception) {
-                    // swallow the exception
+                    trigger_error($exception->getMessage(), E_USER_WARNING);
                 }
             }
         }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -88,6 +88,33 @@ class LoggerTest extends TestCase
         $this->logger->log(self::ANY_LOG_LEVEL, self::A_MESSAGE, [self::A_CONTEXT_KEY => self::A_CONTEXT_VALUE]);
     }
 
+    public function test_WriterThrowException_Log_ShouldCatchExceptionAndTriggerError(): void
+    {
+        $errorHandled = 0;
+        $handledTriggedError = false;
+        set_error_handler(function ($errno, $errstr) use (
+            &$handledTriggedError,
+            &$errorHandled
+        ) {
+            $errorHandled++;
+            $handledTriggedError = ($errno == E_USER_WARNING && $errstr == self::WRITER_LOG_EXCEPTION_MESSAGE);
+        });
+
+        try {
+            $this->givenWriterCanLog();
+            $this->writer->method('log')->willThrowException(new \Exception(self::WRITER_LOG_EXCEPTION_MESSAGE));
+
+            $this->logger->log(self::ANY_LOG_LEVEL, self::A_MESSAGE, [self::A_CONTEXT_KEY => self::A_CONTEXT_VALUE]);
+
+            self::assertGreaterThanOrEqual(1, $errorHandled);
+            self::assertTrue($handledTriggedError);
+        }
+        finally {
+            // making sure that no matter what happens in my test, PHPUnit error handler is put back
+            restore_error_handler();
+        }
+    }
+
     public function test_exception_logExceptionWithContext(): void
     {
         $this->givenWriterCanLog();


### PR DESCRIPTION
[CRM-27749](https://equisoft.atlassian.net/browse/CRM-27749)

PHP 8.4 - arrête d'utiliser E_USER_ERROR

nous [ne pouvons plus](https://www.php.net/manual/en/migration84.deprecated.php) appeler la méthode trigger_error avec E_USER_ERROR

**Tests fonctionnels**
- [x] rien à tester

[CRM-27749]: https://equisoft.atlassian.net/browse/CRM-27749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ